### PR TITLE
Fix maven-enforcer-plugin version range syntax error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
 
                                                 For more information, check the project documentation.
                                             </message>
-                                            <version>${java.version})</version>
+                                            <version>[${java.version},)</version>
                                         </requireJavaVersion>
                                     </rules>
                                     <failFast>true</failFast>


### PR DESCRIPTION
The requireJavaVersion rule had a malformed version range syntax. Changed from '${java.version})' to '[${java.version},)' to properly specify Java 17 or higher requirement using correct Maven version range format.

This fixes the build failure introduced in PR #2.