### PR TITLE
Claude/fix post merge build 011 c uvx q ph cv49h hj4 eruw ea

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -143,7 +143,7 @@ jobs:
         run: ./mvnw -B clean install -P buildDocker --file pom.xml
 
       - name: Start services with Docker Compose
-        run: docker-compose up -d config-server discovery-server customers-service visits-service vets-service api-gateway admin-server
+        run: docker compose up -d config-server discovery-server customers-service visits-service vets-service api-gateway admin-server
         env:
           OPENAI_API_KEY: "test-key"
 
@@ -172,11 +172,11 @@ jobs:
 
       - name: Show service logs on failure
         if: failure()
-        run: docker-compose logs
+        run: docker compose logs
 
       - name: Stop services
         if: always()
-        run: docker-compose down -v
+        run: docker compose down -v
 
   security-scan:
     name: Security Scan

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
 
                                                 For more information, check the project documentation.
                                             </message>
-                                            <version>${java.version})</version>
+                                            <version>[${java.version},)</version>
                                         </requireJavaVersion>
                                     </rules>
                                     <failFast>true</failFast>


### PR DESCRIPTION
Update docker-compose to docker compose in GitHub Actions
GitHub Actions runners now use Docker Compose V2, which uses the
'docker compose' command instead of the legacy 'docker-compose'.

Updated all three instances in the integration-test job:
- Starting services: docker compose up
- Showing logs on failure: docker compose logs
- Stopping services: docker compose down

This fixes the "docker-compose: command not found" error in the
integration-test job.